### PR TITLE
add waitforTransform to prevent lookupexception

### DIFF
--- a/src/localization_plugin.cpp
+++ b/src/localization_plugin.cpp
@@ -106,7 +106,7 @@ void LocalizationPlugin::configure(tue::Configuration config)
     if (nh.getParam("initialpose", ros_param_position))
     {
 
-        //Make a homogeneous transformation with the variables from the parameter server
+        // Make a homogeneous transformation with the variables from the parameter server
         tf::Transform homogtrans_map_odom;
         homogtrans_map_odom.setOrigin(tf::Vector3(ros_param_position["x"], ros_param_position["y"], 0.0));
         tf::Quaternion q_map_odom;
@@ -116,14 +116,14 @@ void LocalizationPlugin::configure(tue::Configuration config)
         // Get homogeneous transformation between odom and base link frame
         tf::StampedTransform tf_odom_base_link;
 
-        //Set to zero, in case of error when looking up, because can't break an if loop in case of error, so we need to proceed with empty transform.
+        // Set to zero, in case of error when looking up, because can't break an if loop in case of error, so we need to proceed with empty transform.
         if (tf_listener_->waitForTransform(odom_frame_id_, base_link_frame_id_, ros::Time(0), ros::Duration(1)))
         {
             try
             {
                 tf_listener_->lookupTransform(odom_frame_id_, base_link_frame_id_, ros::Time(0), tf_odom_base_link);
                 // Calculate base link position in map frame
-                tf::Transform tf_map_base_link = homogtrans_map_odom*tf_odom_base_link;
+                tf::Transform tf_map_base_link = homogtrans_map_odom * tf_odom_base_link;
                 tf::Vector3 pos_map_baselink = tf_map_base_link.getOrigin(); // Returns a vector
                 tf::Quaternion rotation_map_baselink = tf_map_base_link.getRotation(); // Returns a quaternion
 
@@ -135,11 +135,11 @@ void LocalizationPlugin::configure(tue::Configuration config)
             }
             catch (tf::TransformException ex)
             {
-                ROS_ERROR("[ED Localisation] %s",ex.what());
+                ROS_ERROR("[ED Localization] %s",ex.what());
             }
         }
         else
-            ROS_ERROR("[ED Localisation] no transform between odom and base_link.");
+            ROS_ERROR("[ED Localization] no transform between odom and base_link.");
 
     }
     else if (config.readGroup("initial_pose", tue::OPTIONAL))
@@ -151,7 +151,7 @@ void LocalizationPlugin::configure(tue::Configuration config)
     }
 
     particle_filter_.initUniform(p - geo::Vec2(0.3, 0.3), p + geo::Vec2(0.3, 0.3), 0.05,
-                                    yaw - 0.1, yaw + 0.1, 0.05);
+                                 yaw - 0.1, yaw + 0.1, 0.05);
 
     config.value("robot_name", robot_name_);
 

--- a/src/localization_plugin.cpp
+++ b/src/localization_plugin.cpp
@@ -116,7 +116,7 @@ void LocalizationPlugin::configure(tue::Configuration config)
         // Get homogeneous transformation between odom and base link frame
         tf::StampedTransform tf_odom_base_link;
 
-        //Set to zero, in case of error when looking up, because can't break an if loop in case of error.
+        //Set to zero, in case of error when looking up, because can't break an if loop in case of error, so we need to proceed with empty transform.
         tf_odom_base_link.frame_id_ = odom_frame_id_;
         tf_odom_base_link.child_frame_id_ = base_link_frame_id_;
         tf_odom_base_link.stamp_ = ros::Time::now();


### PR DESCRIPTION
This should fix tue-robotics/tue_robocup#522, ED crashing during configure.

An LoopUpException is raised. in the lookuptransform. While the transform is available. It does give the error shown in tue-robotics/tue_robocup#522. Adding the waitfortransform already solved the issue in my opinion, it didn't show up, when restarting free-mode ~15 times. To make it more robust I added a try/catch.

How to test: Start amigo-free-mode on AMIGO multiple times.